### PR TITLE
Changing testing ci to only run on linux

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,21 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Poetry and add to path on Windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
-        echo "${HOME}/.poetry/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-    - name: Install Poetry and add to path on Mac and Linux
-      if: matrix.os != 'windows-latest'
+    - name: Install Poetry and add to path
       run: |
         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
         echo "${HOME}/.poetry/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Changing CI tests to only run on Linux because of GitHub Actions are not able to run docker on Windows and Mac