### PR TITLE
Primary key removed form update documents

### DIFF
--- a/async_search_client/index.py
+++ b/async_search_client/index.py
@@ -179,13 +179,8 @@ class Index:
         response = await self._http_requests.post(url, documents)
         return UpdateId(**response.json())
 
-    async def update_documents(
-        self, documents: list[dict], primary_key: Optional[str] = None
-    ) -> UpdateId:
+    async def update_documents(self, documents: list[dict]) -> UpdateId:
         url = url = build_url(Paths.INDEXES, self.uid, Paths.DOCUMENTS)
-        if primary_key:
-            formatted_primary_key = urlencode({"primaryKey": primary_key})
-            url = f"{url}?{formatted_primary_key}"
 
         response = await self._http_requests.put(url, documents)
         return UpdateId(**response.json())

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -80,20 +80,6 @@ async def test_update_documents(index_with_documents, small_movies):
     assert response[0]["title"] != "Some title"
 
 
-@pytest.mark.skip(
-    message="This test is failing and I am not sure why. The issue is in https://github.com/meilisearch/meilisearch-python/issues/224"
-)
-@pytest.mark.asyncio
-async def test_update_documents_with_primary_key(test_client, small_movies):
-    primary_key = "title"
-    index = test_client.index("movies")
-    update = await index.update_documents(small_movies, primary_key=primary_key)
-    await index.wait_for_pending_update(update.update_id)
-    response = await index.get_documents()
-    assert response[0]["title"] != "Some title"
-    assert await index.get_primary_key() == primary_key
-
-
 @pytest.mark.asyncio
 async def test_delete_document(index_with_documents):
     index = await index_with_documents()


### PR DESCRIPTION
Removed based on conversation here https://github.com/meilisearch/meilisearch-python/issues/224. Should consider re-adding based on new information 