### PR TITLE
Re-adding primary_key to update_documents

### DIFF
--- a/async_search_client/index.py
+++ b/async_search_client/index.py
@@ -179,8 +179,13 @@ class Index:
         response = await self._http_requests.post(url, documents)
         return UpdateId(**response.json())
 
-    async def update_documents(self, documents: list[dict]) -> UpdateId:
+    async def update_documents(
+        self, documents: list[dict], primary_key: Optional[str] = None
+    ) -> UpdateId:
         url = url = build_url(Paths.INDEXES, self.uid, Paths.DOCUMENTS)
+        if primary_key:
+            formatted_primary_key = urlencode({"primaryKey": primary_key})
+            url = f"{url}?{formatted_primary_key}"
 
         response = await self._http_requests.put(url, documents)
         return UpdateId(**response.json())

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -20,7 +20,7 @@ async def test_add_documents(empty_index, small_movies):
 
 
 @pytest.mark.skip(
-    message="This test is failing and I am not sure why. The issue is in https://github.com/meilisearch/meilisearch-python/issues/224"
+    message="This test is failing. There are ongoing discussions with the MeiliSearch team on how to handle this"
 )
 @pytest.mark.asyncio
 async def test_add_documents_with_primary_key(empty_index, small_movies):
@@ -78,6 +78,20 @@ async def test_update_documents(index_with_documents, small_movies):
     await index.wait_for_pending_update(update.update_id)
     response = await index.get_documents()
     assert response[0]["title"] != "Some title"
+
+
+@pytest.mark.skip(
+    message="This test is failing. There are ongoing discussions with the MeiliSearch team on how to handle this"
+)
+@pytest.mark.asyncio
+async def test_update_documents_with_primary_key(test_client, small_movies):
+    primary_key = "title"
+    index = test_client.index("movies")
+    update = await index.update_documents(small_movies, primary_key=primary_key)
+    await index.wait_for_pending_update(update.update_id)
+    response = await index.get_documents()
+    assert response[0]["title"] != "Some title"
+    assert await index.get_primary_key() == primary_key
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After discussions the the MeiliSearch team I am adding the primary key back in here for now. They are going to have discussions internally on the best way to handle the issues seen with this so further updates may be needed here in the future.