### PR TITLE
Adding Python 3.10 to tox

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10.0-beta - 3.10.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10.0-beta - 3.10.0']
+        python-version: [3.7, 3.8, 3.9, '3.10.0-beta.1 - 3.10.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10.0-beta.1 - 3.10.0']
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = isort, flake8, black, mypy, py37, py38, py39
+envlist = isort, flake8, black, mypy, py37, py38, py39, py310
 
 [testenv:isort]
 whitelist_externals = poetry


### PR DESCRIPTION
Python 3.10 tests to tox. 3.10 is still failing the missing cleo message in GitHub Actions so leaving out of CI for now.