### PR TITLE
Moving internal blocking calls to executor

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = isort, flake8, black, mypy, py37, py38, py39, py310
+envlist = isort, flake8, black, mypy, py37, py38, py39
 
 [testenv:isort]
 whitelist_externals = poetry


### PR DESCRIPTION
Some internal function calls were blocking. These were moving into an executor to prevent blocking the main thread.