### PR TITLE
Moved mypy settings to pyproject.toml

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-disallow_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ src_paths = ["async_search_client", "tests"]
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--cov=async_search_client"
+
+[tool.mypy]
+disallow_untyped_defs = true


### PR DESCRIPTION
MyPy allows setting to be in the pyproject.toml file starting with v0.900 so moving them there and removing the mypy.ini file.