### PR TITLE
Changing CI to the new poetry install script and adding 3.10 to tests

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -18,8 +18,8 @@ jobs:
         python-version: 3.9
     - name: Install Poetry and add to path
       run: |
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-        echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
     - name: Install Dependencies
       run: |
         poetry install
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10.0-beta - 3.10.0"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
@@ -53,8 +53,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry and add to path
       run: |
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-        echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
+    - name: Poetry configuration
+      if: matrix.python-version == '3.10.0-beta - 3.10.0'  # Poetry installs are currently failing with the experimental installer on 3.10
+      run: |
+        poetry config experimental.new-installer false
     - name: Install Dependencies
       run: |
         poetry install


### PR DESCRIPTION
Poetry has a new install script so changing to using that script. It is also fixes the error with Python 3.10 so adding that to the test matrix.